### PR TITLE
Create SQS queue IaC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,12 +8,13 @@ module "simple_lambdas" {
   producer_zip_path = "${path.module}/lambda/producer.zip"
   consumer_zip_path = "${path.module}/lambda/consumer.zip"
 
+  sqs_queue_url = module.sqs.queue_url
+
   tags = {
     project = "simple-lambdas"
     owner   = "isaac"
   }
 }
-
 
 module "api_gateway" {
   source = "./modules/api_gateway"
@@ -27,3 +28,14 @@ module "api_gateway" {
     Environment = "dev"
   }
 }
+
+module "sqs" {
+  source     = "./modules/sqs"
+  queue_name = "books-queue"
+
+  tags = {
+    project = "simple-lambdas"
+    owner   = "isaac"
+  }
+}
+

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -46,6 +46,13 @@ resource "aws_lambda_function" "producer" {
   timeout          = var.lambda_timeout
   source_code_hash = filebase64sha256(var.producer_zip_path)
   tags             = var.tags
+
+environment {
+    variables = merge(
+      {},
+      var.sqs_queue_url != "" ? { SQS_URL = var.sqs_queue_url } : {}
+    )
+  }
 }
 
 # Consumer

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -27,3 +27,9 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "sqs_queue_url" {
+  type        = string
+  description = "SQS queue URL to be injected into the producer lambda (optional)"
+  default     = ""
+}

--- a/modules/sqs/main.tf
+++ b/modules/sqs/main.tf
@@ -1,0 +1,5 @@
+resource "aws_sqs_queue" "this" {
+  name = var.queue_name
+
+  tags = var.tags
+}

--- a/modules/sqs/outputs.tf
+++ b/modules/sqs/outputs.tf
@@ -1,0 +1,9 @@
+output "queue_url" {
+  description = "URL of the SQS queue"
+  value       = aws_sqs_queue.this.id
+}
+
+output "queue_arn" {
+  description = "ARN of the SQS queue"
+  value       = aws_sqs_queue.this.arn
+}

--- a/modules/sqs/variables.tf
+++ b/modules/sqs/variables.tf
@@ -1,0 +1,10 @@
+variable "queue_name" {
+  type        = string
+  description = "Name of the SQS Queue"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags for SQS"
+  default     = {}
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,11 @@
 output "api_endpoint" {
   value = module.api_gateway.api_endpoint
 }
+
+output "sqs_queue_url" {
+  value = module.sqs.queue_url
+}
+
+output "sqs_queue_arn" {
+  value = module.sqs.queue_arn
+}


### PR DESCRIPTION
This pull request adds the initial SQS infrastructure required for the message processing workflow.
A new Terraform module (modules/sqs) was created to define and manage an SQS queue that will be used by the Producer Lambda to send messages and by the Consumer Lambda to process them.

Key Changes

- Added new Terraform module to create the SQS queue (books-queue).

- Exposed queue URL and ARN as module outputs.

- Integrated the SQS module into main.tf at the root level.

- Prepared the queue for future integration with Lambda Producer and Consumer.

- No IAM permissions added yet (these will be included in a separate PR).

Closes #10