### PR TITLE
Create IAM roles and policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,33 +2,9 @@ provider "aws" {
   region = local.region
 }
 
-module "simple_lambdas" {
-  source = "./modules/lambdas"
-
-  producer_zip_path = "${path.module}/lambda/producer.zip"
-  consumer_zip_path = "${path.module}/lambda/consumer.zip"
-
-  sqs_queue_url = module.sqs.queue_url
-
-  tags = {
-    project = "simple-lambdas"
-    owner   = "isaac"
-  }
-}
-
-module "api_gateway" {
-  source = "./modules/api_gateway"
-
-  name                 = var.api_name
-  region               = var.region
-  producer_lambda_arn  = module.simple_lambdas.producer_lambda_arn
-  consumer_lambda_arn  = module.simple_lambdas.consumer_lambda_arn
-
-  tags = {
-    Environment = "dev"
-  }
-}
-
+# -----------------------
+# 1) SQS (prerequisito)
+# -----------------------
 module "sqs" {
   source     = "./modules/sqs"
   queue_name = "books-queue"
@@ -39,6 +15,9 @@ module "sqs" {
   }
 }
 
+# -----------------------
+# 2) DynamoDB (prerequisito)
+# -----------------------
 module "dynamodb" {
   source = "./modules/dynamodb"
 
@@ -46,7 +25,7 @@ module "dynamodb" {
   billing_mode = "PAY_PER_REQUEST"
 
   hash_key  = "pk"
-  range_key = "" # no sort key, puedes poner "sk" si quieres
+  range_key = "" # no sort key
 
   attributes = [
     { name = "pk", type = "S" }
@@ -59,5 +38,62 @@ module "dynamodb" {
   tags = {
     project = "simple-lambdas"
     owner   = "isaac"
+  }
+}
+
+# -----------------------
+# 3) IAM roles (usa ARNs de SQS y Dynamo)
+# -----------------------
+module "iam" {
+  source = "./modules/iam"
+
+  name_prefix        = "simple-lib"
+  producer_sqs_arn   = module.sqs.queue_arn        # <-- asegurate que module.sqs exporte queue_arn
+  consumer_sqs_arn   = module.sqs.queue_arn
+  dynamodb_table_arn = module.dynamodb.table_arn   # <-- asegurate que module.dynamodb exporte table_arn
+
+  tags = {
+    project = "simple-lambdas"
+    owner   = "isaac"
+  }
+}
+
+# -----------------------
+# 4) Lambdas (usa role ARNs y queue URL)
+# -----------------------
+module "simple_lambdas" {
+  source = "./modules/lambdas"
+
+  producer_zip_path = "${path.module}/lambda/producer.zip"
+  consumer_zip_path = "${path.module}/lambda/consumer.zip"
+
+  sqs_queue_url     = module.sqs.queue_url
+  dynamodb_table_name = module.dynamodb.table_name
+
+  producer_role_arn = module.iam.producer_role_arn
+  consumer_role_arn = module.iam.consumer_role_arn
+
+  tags = {
+    project = "simple-lambdas"
+    owner   = "isaac"
+  }
+}
+
+
+# -----------------------
+# 5) API Gateway (invoca producer lambda)
+# -----------------------
+module "api_gateway" {
+  source = "./modules/api_gateway"
+
+  name                 = var.api_name
+  region               = var.region
+
+  # el API invoca la lambda producer: se necesita el ARN de la lambda
+  producer_lambda_arn  = module.simple_lambdas.producer_lambda_arn
+  consumer_lambda_arn  = module.simple_lambdas.consumer_lambda_arn
+
+  tags = {
+    Environment = "dev"
   }
 }

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -1,0 +1,113 @@
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "producer" {
+  name               = "${var.name_prefix}-producer-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = var.tags
+}
+
+# Attach AWS managed policy for CloudWatch Logs (basic Lambda execution)
+resource "aws_iam_role_policy_attachment" "producer_basic" {
+  role       = aws_iam_role.producer.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# Producer inline policy (least privilege to send messages to SQS)
+resource "aws_iam_role_policy" "producer_policy" {
+  name = "${var.name_prefix}-producer-inline-policy"
+  role = aws_iam_role.producer.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:SendMessage",
+          "sqs:SendMessageBatch",
+          "sqs:GetQueueAttributes"
+        ]
+        Resource = var.producer_sqs_arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+# --- Consumer Role ---
+resource "aws_iam_role" "consumer" {
+  name               = "${var.name_prefix}-consumer-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "consumer_basic" {
+  role       = aws_iam_role.consumer.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# Consumer inline policy (SQS receive/delete + DynamoDB write/read)
+resource "aws_iam_role_policy" "consumer_policy" {
+  name = "${var.name_prefix}-consumer-inline-policy"
+  role = aws_iam_role.consumer.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # SQS permissions
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:ChangeMessageVisibility"
+        ]
+        Resource = var.consumer_sqs_arn
+      },
+
+      # DynamoDB permissions
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:GetItem",
+          "dynamodb:Query",
+          "dynamodb:DescribeTable"
+        ]
+        Resource = var.dynamodb_table_arn
+      },
+
+      # CloudWatch logs
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}

--- a/modules/iam/outputs.tf
+++ b/modules/iam/outputs.tf
@@ -1,0 +1,29 @@
+output "producer_role_arn" {
+  value       = aws_iam_role.producer.arn
+  description = "ARN of the Lambda role for producer"
+}
+
+output "producer_role_name" {
+  value       = aws_iam_role.producer.name
+  description = "Name of the Lambda role for producer"
+}
+
+output "producer_policy_arn" {
+  value       = aws_iam_role_policy.producer_policy.id
+  description = "Inline policy ID for the producer role"
+}
+
+output "consumer_role_arn" {
+  value       = aws_iam_role.consumer.arn
+  description = "ARN of the Lambda role for consumer"
+}
+
+output "consumer_role_name" {
+  value       = aws_iam_role.consumer.name
+  description = "Name of the Lambda role for consumer"
+}
+
+output "consumer_policy_arn" {
+  value       = aws_iam_role_policy.consumer_policy.id
+  description = "Inline policy ID for the consumer role"
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -1,0 +1,32 @@
+variable "name_prefix" {
+  description = "Prefix for IAM role names"
+  type        = string
+  default     = "simple-lib"
+}
+
+variable "producer_sqs_arn" {
+  description = "ARN of the SQS queue used by the producer (SendMessage)"
+  type        = string
+}
+
+variable "consumer_sqs_arn" {
+  description = "ARN of the SQS queue used by the consumer (Receive/Delete)"
+  type        = string
+}
+
+variable "dynamodb_table_arn" {
+  description = "ARN of the DynamoDB table where consumer writes records"
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "Optional KMS key ARN if DynamoDB uses KMS-managed encryption"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags to add to the IAM roles"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -1,53 +1,16 @@
-locals {
-  lambda_assume_role = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action    = "sts:AssumeRole"
-      Effect    = "Allow"
-      Principal = { Service = "lambda.amazonaws.com" }
-    }]
-  })
-}
-
-# Role for lambdas (basic logging)
-resource "aws_iam_role" "lambda_role" {
-  name               = "simple-lambda-role"
-  assume_role_policy = local.lambda_assume_role
-}
-
-resource "aws_iam_role_policy" "lambda_logging" {
-  name = "simple-lambda-logging"
-  role = aws_iam_role.lambda_role.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = [
-          "logs:CreateLogGroup",
-          "logs:CreateLogStream",
-          "logs:PutLogEvents"
-        ]
-        Effect   = "Allow"
-        Resource = "arn:aws:logs:*:*:*"
-      }
-    ]
-  })
-}
-
-# Producer
+# --- Producer Lambda ---
 resource "aws_lambda_function" "producer" {
   filename         = var.producer_zip_path
-  function_name    = "producer-simple"
-  role             = aws_iam_role.lambda_role.arn
-  handler          = "producer.lambda_handler"
+  function_name    = var.producer_function_name
+  role             = var.producer_role_arn        # ARN proveniente de module.iam
+  handler          = var.producer_handler
   runtime          = var.lambda_runtime
   memory_size      = var.lambda_memory_size
   timeout          = var.lambda_timeout
   source_code_hash = filebase64sha256(var.producer_zip_path)
   tags             = var.tags
 
-environment {
+  environment {
     variables = merge(
       {},
       var.sqs_queue_url != "" ? { SQS_URL = var.sqs_queue_url } : {}
@@ -55,15 +18,22 @@ environment {
   }
 }
 
-# Consumer
+# --- Consumer Lambda ---
 resource "aws_lambda_function" "consumer" {
   filename         = var.consumer_zip_path
-  function_name    = "consumer-simple"
-  role             = aws_iam_role.lambda_role.arn
-  handler          = "consumer.lambda_handler"
+  function_name    = var.consumer_function_name
+  role             = var.consumer_role_arn      # ARN proveniente de module.iam
+  handler          = var.consumer_handler
   runtime          = var.lambda_runtime
   memory_size      = var.lambda_memory_size
   timeout          = var.lambda_timeout
   source_code_hash = filebase64sha256(var.consumer_zip_path)
   tags             = var.tags
+
+  environment {
+    variables = merge(
+      {},
+      var.dynamodb_table_name != "" ? { TABLE_NAME = var.dynamodb_table_name } : {}
+    )
+  }
 }

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -8,28 +8,72 @@ variable "consumer_zip_path" {
   type        = string
 }
 
+variable "producer_function_name" {
+  description = "Name for the producer lambda function"
+  type        = string
+  default     = "producer-simple"
+}
+
+variable "consumer_function_name" {
+  description = "Name for the consumer lambda function"
+  type        = string
+  default     = "consumer-simple"
+}
+
+variable "producer_handler" {
+  description = "Handler for the producer lambda (module-level default)"
+  type        = string
+  default     = "producer.lambda_handler"
+}
+
+variable "consumer_handler" {
+  description = "Handler for the consumer lambda (module-level default)"
+  type        = string
+  default     = "consumer.lambda_handler"
+}
+
+variable "producer_role_arn" {
+  description = "ARN of the IAM role to be used by the producer lambda (from modules/iam)"
+  type        = string
+}
+
+variable "consumer_role_arn" {
+  description = "ARN of the IAM role to be used by the consumer lambda (from modules/iam)"
+  type        = string
+}
+
 variable "lambda_runtime" {
-  type    = string
-  default = "python3.9"
+  description = "Lambda runtime"
+  type        = string
+  default     = "python3.9"
 }
 
 variable "lambda_memory_size" {
-  type    = number
-  default = 128
+  description = "Memory (MB) for the lambdas"
+  type        = number
+  default     = 128
 }
 
 variable "lambda_timeout" {
-  type    = number
-  default = 10
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
+  description = "Timeout (seconds) for the lambdas"
+  type        = number
+  default     = 10
 }
 
 variable "sqs_queue_url" {
-  type        = string
   description = "SQS queue URL to be injected into the producer lambda (optional)"
+  type        = string
   default     = ""
+}
+
+variable "dynamodb_table_name" {
+  description = "DynamoDB table name to be injected into the consumer lambda (optional)"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags to apply to lambda resources"
+  type        = map(string)
+  default     = {}
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,11 @@ output "sqs_queue_url" {
 output "dynamodb_table_id" {
   value = module.dynamodb.table_id
 }
+
+output "consumer_policy_arn" {
+  value = module.iam.consumer_policy_arn
+}
+
+output "producer_policy_arn" {
+  value = module.iam.producer_policy_arn
+}


### PR DESCRIPTION
Added dedicated IAM roles for:

Producer Lambda

Consumer Lambda

- Implemented least-privilege IAM policies, including:

- SQS permissions (SendMessage / ReceiveMessage / DeleteMessage)

- DynamoDB permissions (PutItem / GetItem)

- CloudWatch Logs permissions via AWS managed policy

- Exposed IAM outputs to be consumed by the Lambda module:

producer_role_arn
consumer_role_arn

- Integrated these roles in the root module so Lambdas can reference them.

Closes #12