### PR TITLE
Add S3 backend configuration for Terraform state

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,14 @@ provider "aws" {
   region = local.region
 }
 
+terraform {
+  backend "s3" {
+    bucket = "library-epam-cloud-platform"
+    key    = "terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+
 module "sqs" {
   source = "./modules/sqs"
   queue_name        = "books-queue"


### PR DESCRIPTION
Changes made:

Configured terraform { backend "s3" { ... } } in the main Terraform configuration.
Bucket: library-epam-cloud-platform
Key: terraform.tfstate
Region: us-east-1

Closes: #33 